### PR TITLE
Switch liboqs build to CMake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       before_install:
         - rm -rf /usr/local/include/c++
         - brew update
-        - brew install gcc6 cmake ninja
+        - brew install gcc6 ninja
 
     # OSX gcc6
     - os: osx
@@ -25,7 +25,7 @@ matrix:
       before_install:
         - rm -rf /usr/local/include/c++
         - brew update
-        - brew install gcc6 cmake ninja
+        - brew install gcc6 ninja
         - export CXX="g++-6" CC="gcc-6"
         - sudo softwareupdate -i "Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.1"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - os: linux
       compiler: gcc
       before_install:
-        - sudo apt-get install autoconf automake
+        - sudo apt-get install cmake ninja-build
 
     # Apple OSX LLVM version 10.0.0 (clang-1000.11.45.5)
     - os: osx
@@ -16,7 +16,7 @@ matrix:
       before_install:
         - rm -rf /usr/local/include/c++
         - brew update
-        - brew install gcc6
+        - brew install gcc6 cmake ninja
 
     # OSX gcc6
     - os: osx
@@ -25,7 +25,7 @@ matrix:
       before_install:
         - rm -rf /usr/local/include/c++
         - brew update
-        - brew install gcc6
+        - brew install gcc6 cmake ninja
         - export CXX="g++-6" CC="gcc-6"
         - sudo softwareupdate -i "Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.1"
 

--- a/.travis/install_liboqs.sh
+++ b/.travis/install_liboqs.sh
@@ -4,6 +4,6 @@ git clone https://github.com/open-quantum-safe/liboqs
 cd liboqs
 git checkout master
 mkdir build && cd build
-cmake -GNinja ..
+cmake -GNinja -DBUILD_SHARED_LIBS=ON ..
 ninja
 ninja install

--- a/.travis/install_liboqs.sh
+++ b/.travis/install_liboqs.sh
@@ -6,4 +6,4 @@ git checkout master
 mkdir build && cd build
 cmake -GNinja -DBUILD_SHARED_LIBS=ON ..
 ninja
-ninja install
+sudo ninja install

--- a/.travis/install_liboqs.sh
+++ b/.travis/install_liboqs.sh
@@ -3,8 +3,7 @@
 git clone https://github.com/open-quantum-safe/liboqs
 cd liboqs
 git checkout master
-autoreconf -i
-./configure
-make clean
-make -j 4
-sudo make install
+mkdir build && cd build
+cmake -GNinja ..
+ninja
+ninja install

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The examples in the [`examples`](https://github.com/open-quantum-safe/liboqs-cpp
 Building on POSIX (Linux/UNIX-like) platforms
 ---------------------------------------------
 
-First, you must build the master branch of liboqs according to the [liboqs building instructions](https://github.com/open-quantum-safe/liboqs#linuxmacos), followed (optionally) by a `sudo make install` to ensure that the compiled library is visible system-wide (by default it installs under `/usr/local/include` and `/usr/local/lib` on Linux/macOS).
+First, you must build the master branch of liboqs according to the [liboqs building instructions](https://github.com/open-quantum-safe/liboqs#linuxmacos), followed (optionally) by a `sudo ninja install` to ensure that the compiled library is visible system-wide (by default it installs under `/usr/local/include` and `/usr/local/lib` on Linux/macOS).
 
 Next, to use the wrapper, you simply `#include "oqs_cpp.h"` in your program. The wrapper contains
 a CMake build system for both examples and unit tests. To compile and run the examples, create a `build` directory inside the root directory of the project, change

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ directory to `build`, then type
 	make -j4
 
 The above commands build all examples in `examples`, i.e. `examples/kem` and `examples/sig`, assuming
-the CMake build system is available on your platform. The `-DLIBOQS_INCLUDE_DIR` and `-DLIBOQS_LIB_DIR` flags specify the location to the liboqs headers and compiled library. You may omit those flags and simply type `cmake .. && make -j4` in case you installed liboqs in `/usr/local` (true if you ran `sudo make install` after building liboqs). You may replace the `-j4` flag with your
+the CMake build system is available on your platform. The `-DLIBOQS_INCLUDE_DIR` and `-DLIBOQS_LIB_DIR` flags specify the location to the liboqs headers and compiled library. You may omit those flags and simply type `cmake .. && make -j4` in case you installed liboqs in `/usr/local` (true if you ran `sudo ninja install` after building liboqs). You may replace the `-j4` flag with your
 processor's number of cores, e.g. use `-j8` if your system has 8 cores.
 To build only a specific example, e.g. `examples/kem`, specify the target as the argument of the `make` command, such as
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The examples in the [`examples`](https://github.com/open-quantum-safe/liboqs-cpp
 Building on POSIX (Linux/UNIX-like) platforms
 ---------------------------------------------
 
-First, you must build the master branch of liboqs according to the [liboqs building instructions](https://github.com/open-quantum-safe/liboqs#linuxmacos), followed (optionally) by a `sudo ninja install` to ensure that the compiled library is visible system-wide (by default it installs under `/usr/local/include` and `/usr/local/lib` on Linux/macOS).
+First, you must build the master branch of liboqs according to the [liboqs building instructions](https://github.com/open-quantum-safe/liboqs#linuxmacos) with shared library support enabled (add `-DBUILD_SHARED_LIBS=ON` to the `cmake` command), followed (optionally) by a `sudo ninja install` to ensure that the compiled library is visible system-wide (by default it installs under `/usr/local/include` and `/usr/local/lib` on Linux/macOS).
 
 Next, to use the wrapper, you simply `#include "oqs_cpp.h"` in your program. The wrapper contains
 a CMake build system for both examples and unit tests. To compile and run the examples, create a `build` directory inside the root directory of the project, change

--- a/VisualStudio/kem/kem.vcxproj
+++ b/VisualStudio/kem/kem.vcxproj
@@ -76,10 +76,10 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\VisualStudio\include;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\build\include;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\VisualStudio\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\build\lib\</AdditionalLibraryDirectories>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;oqs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>
@@ -93,10 +93,10 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\VisualStudio\include;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\build\include;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\VisualStudio\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\build\lib\</AdditionalLibraryDirectories>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;oqs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>
@@ -112,12 +112,12 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\VisualStudio\include;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\build\include;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\VisualStudio\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\build\lib\</AdditionalLibraryDirectories>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;oqs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>
@@ -133,12 +133,12 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\VisualStudio\include;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\build\include;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\VisualStudio\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\build\lib\</AdditionalLibraryDirectories>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;oqs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>

--- a/VisualStudio/rand/rand.vcxproj
+++ b/VisualStudio/rand/rand.vcxproj
@@ -96,14 +96,14 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\VisualStudio\include;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\build\include;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\VisualStudio\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\build\lib\</AdditionalLibraryDirectories>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;oqs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>LIBCMT;</IgnoreSpecificDefaultLibraries>
     </Link>
@@ -117,14 +117,14 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\VisualStudio\include;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\build\include;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;oqs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>LIBCMTD;</IgnoreSpecificDefaultLibraries>
-      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\VisualStudio\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\build\lib\</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -136,12 +136,12 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\VisualStudio\include;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\build\include;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\VisualStudio\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\build\lib\</AdditionalLibraryDirectories>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;oqs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>LIBCMTD;</IgnoreSpecificDefaultLibraries>
     </Link>
@@ -157,7 +157,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\VisualStudio\include;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\build\include;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -166,7 +166,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;oqs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>LIBCMT;</IgnoreSpecificDefaultLibraries>
-      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\VisualStudio\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\build\lib\</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/VisualStudio/sig/sig.vcxproj
+++ b/VisualStudio/sig/sig.vcxproj
@@ -76,10 +76,10 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\VisualStudio\include;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\build\include;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\VisualStudio\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\build\lib\</AdditionalLibraryDirectories>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;oqs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
       <IgnoreSpecificDefaultLibraries>LIBCMTD;</IgnoreSpecificDefaultLibraries>
@@ -91,10 +91,10 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\VisualStudio\include;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\build\include;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\VisualStudio\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\build\lib\</AdditionalLibraryDirectories>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;oqs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
       <IgnoreSpecificDefaultLibraries>LIBCMTD;</IgnoreSpecificDefaultLibraries>
@@ -108,12 +108,12 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\VisualStudio\include;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\build\include;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\VisualStudio\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\build\lib\</AdditionalLibraryDirectories>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;oqs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
       <IgnoreSpecificDefaultLibraries>LIBCMT;</IgnoreSpecificDefaultLibraries>
@@ -127,12 +127,12 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\VisualStudio\include;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\build\include;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\VisualStudio\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\build\lib\</AdditionalLibraryDirectories>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;oqs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
       <IgnoreSpecificDefaultLibraries>LIBCMT;</IgnoreSpecificDefaultLibraries>

--- a/VisualStudio/unit_tests/unit_tests.vcxproj
+++ b/VisualStudio/unit_tests/unit_tests.vcxproj
@@ -76,11 +76,11 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\VisualStudio\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googletest\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googletest\;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googlemock\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googlemock;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\build\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googletest\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googletest\;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googlemock\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googlemock;</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\VisualStudio\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\build\lib\</AdditionalLibraryDirectories>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;oqs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>LIBCMTD;</IgnoreSpecificDefaultLibraries>
       <SubSystem>Console</SubSystem>
@@ -96,11 +96,11 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\VisualStudio\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googletest\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googletest\;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googlemock\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googlemock;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\build\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googletest\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googletest\;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googlemock\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googlemock;</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\VisualStudio\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\build\lib\</AdditionalLibraryDirectories>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;oqs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>LIBCMTD;</IgnoreSpecificDefaultLibraries>
       <SubSystem>Console</SubSystem>
@@ -118,13 +118,13 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\VisualStudio\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googletest\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googletest\;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googlemock\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googlemock;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\build\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googletest\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googletest\;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googlemock\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googlemock;</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\VisualStudio\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\build\lib\</AdditionalLibraryDirectories>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;oqs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>LIBCMT;</IgnoreSpecificDefaultLibraries>
       <SubSystem>Console</SubSystem>
@@ -142,13 +142,13 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\VisualStudio\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googletest\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googletest\;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googlemock\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googlemock;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\include;$(LIBOQS_INSTALL_PATH)\build\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googletest\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googletest\;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googlemock\include;$(SolutionDir)..\unit_tests\lib\googletest-release-1.8.1\googlemock;</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\VisualStudio\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LIBOQS_INSTALL_PATH)\build\lib\</AdditionalLibraryDirectories>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;oqs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>LIBCMT;</IgnoreSpecificDefaultLibraries>
       <SubSystem>Console</SubSystem>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,29 +1,32 @@
 version: 1.0.{build}
 
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 platform: x64
 
 environment:
     LIBOQS_INSTALL_PATH: C:\liboqs
-    
+
 init:
-  - git clone https://github.com/open-quantum-safe/liboqs %LIBOQS_INSTALL_PATH%
-  - msbuild /m /p:configuration=Debug C:\liboqs\VisualStudio\liboqs.sln /nologo /noconsolelogger
-  - msbuild /m /p:configuration=Release C:\liboqs\VisualStudio\liboqs.sln /nologo /noconsolelogger
-    
+    - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+    - set PATH="C:\\Python37";"C:\\Python37\Scripts";%PATH%    
+    - git clone https://github.com/open-quantum-safe/liboqs %LIBOQS_INSTALL_PATH%
+    - cd %LIBOQS_INSTALL_PATH%
+    - mkdir build
+    - cd build
+    - cmake .. -G"Ninja" -DBUILD_SHARED_LIBS=ON
+    - ninja 1> nul
+
 build:
     project: VisualStudio/liboqs-cpp.sln
     verbosity: minimal
     parallel: true
 
-configuration:
-    - Debug
-    - Release
-
 test_script:
     - cmd: >-
         %APPVEYOR_BUILD_FOLDER%\VisualStudio\%PLATFORM%\%CONFIGURATION%\kem
+
+        %APPVEYOR_BUILD_FOLDER%\VisualStudio\%PLATFORM%\%CONFIGURATION%\rand
 
         %APPVEYOR_BUILD_FOLDER%\VisualStudio\%PLATFORM%\%CONFIGURATION%\sig
 

--- a/unit_tests/tests/test_kem.cpp
+++ b/unit_tests/tests/test_kem.cpp
@@ -32,7 +32,7 @@ void test_kem(const std::string& kem_name) {
 
 TEST(oqs_KeyEncapsulation, Enabled) {
     std::vector<std::thread> thread_pool;
-    auto enabled_KEMs = oqs::KEMs::get_enabled_KEMs();
+    std::vector<std::string> enabled_KEMs = oqs::KEMs::get_enabled_KEMs();
     thread_pool.reserve(enabled_KEMs.size());
     for (auto&& kem_name : enabled_KEMs) {
         std::cout << kem_name << std::endl;

--- a/unit_tests/tests/test_kem.cpp
+++ b/unit_tests/tests/test_kem.cpp
@@ -32,15 +32,18 @@ void test_kem(const std::string& kem_name) {
 
 TEST(oqs_KeyEncapsulation, Enabled) {
     std::vector<std::thread> thread_pool;
-    thread_pool.reserve(oqs::KEMs::get_enabled_KEMs().size());
-    for (auto&& kem_name : oqs::KEMs::get_enabled_KEMs()) {
+    auto enabled_KEMs = oqs::KEMs::get_enabled_KEMs();
+    thread_pool.reserve(enabled_KEMs.size());
+    for (auto&& kem_name : enabled_KEMs) {
         std::cout << kem_name << std::endl;
         // issues with stack size being too small in macOS (512Kb for threads)
         if (kem_name != "LEDAcryptKEM-LT52")
             thread_pool.emplace_back(std::thread(test_kem, kem_name));
     }
     // test LEDAcryptKEM-LT52 in the main thread (stack size is 8Mb on macOS)
-    test_kem("LEDAcryptKEM-LT52");
+    if (std::find(std::begin(enabled_KEMs), std::end(enabled_KEMs),
+                  "LEDAcryptKEM-LT52") != std::end(enabled_KEMs))
+        test_kem("LEDAcryptKEM-LT52");
     // join the rest of the threads
     for (auto&& elem : thread_pool)
         elem.join();


### PR DESCRIPTION
@vsoftco I started to switch liboqs build to CMake, but only know how to do it on Linux/macOS. The Windows instructions and AppVeyor CI need to be updated.